### PR TITLE
using #exteriorRing

### DIFF
--- a/src/KML-Core/KMLPolygon.class.st
+++ b/src/KML-Core/KMLPolygon.class.st
@@ -24,10 +24,10 @@ KMLPolygon >> altitudeMode: anObject [
 
 { #category : #accessing }
 KMLPolygon >> outerBoundary [
-	^ self exterorRing
+	^ self exteriorRing
 ]
 
 { #category : #accessing }
 KMLPolygon >> outerBoundary: anOGCLinearRing [ 
-	self exterorRing: anOGCLinearRing 
+	self exteriorRing: anOGCLinearRing 
 ]


### PR DESCRIPTION
KML depends on #master of OGC, which now changed #exterorRing to #exteriorRing